### PR TITLE
fix:The 'Pods-Runner' target has transitive dependencies that include statically linked binaries

### DIFF
--- a/ios/rammus.podspec
+++ b/ios/rammus.podspec
@@ -19,6 +19,7 @@ A new Flutter plugin for AliCloud push.
 
   s.frameworks = ["SystemConfiguration", "CoreTelephony"]
   s.libraries = ["z", "sqlite3.0", "resolv"]
+  s.static_framework = true
 
   s.ios.deployment_target = '8.0'
 end


### PR DESCRIPTION
iOS运行时，pod install报错。
jpush/jmessage-flutter-plugin#3
在ios文件夹里面的flutter_bugly.podspec文件中中添加s.static_framework = true（在end前面一排即可！)
解决了这个问题